### PR TITLE
feat: Ajout modale modification annonce + filtres à venir/passées

### DIFF
--- a/src/app/pages/annonces/mes-annonces/mes-annonces.css
+++ b/src/app/pages/annonces/mes-annonces/mes-annonces.css
@@ -6,6 +6,14 @@
   background: #EDEDED;
 }
 
+/* Fixe le footer en bas */
+.page-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: #EDEDED;
+}
+
 /* Zone de contenu principale */
 .mes-annonces-container {
   flex: 1;
@@ -20,12 +28,11 @@
 
 /* Titre de la page */
 .page-title {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 600;
   letter-spacing: 0.5px;
   color: #333;
-  margin-top: 0.1rem;
-  margin-bottom: 10px;
+  margin: 0 0 10px 0;
   text-align: center;
   text-transform: uppercase;
 }
@@ -62,6 +69,52 @@
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
+}
+
+/* Styles pour les filtres */
+.filters-container {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  justify-content: start;
+}
+
+.filter-btn {
+  padding: 0.4rem 1.5rem;
+  border: 2px solid #0B84A2;
+  background: white;
+  color: #0B84A2;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.filter-btn:hover {
+  background: #E6F7FB;
+}
+
+.filter-btn.active {
+  background: #0B84A2;
+  color: white;
+}
+
+/* Style pour les lignes d'annonces passées */
+.row-passee {
+  background-color: #f5f5f5 !important;
+  opacity: 0.7;
+}
+
+.row-passee td {
+  color: #888 !important;
+}
+
+.row-passee .vehicle-photo {
+  opacity: 0.6;
+  filter: grayscale(50%);
 }
 
 /* Conteneur de la carte/tableau */
@@ -293,6 +346,7 @@
 .action-button-container {
   display: flex;
   justify-content: center;
+  margin-top: 1rem;
 }
 
 .btn-poster-annonce {

--- a/src/app/pages/annonces/mes-annonces/mes-annonces.html
+++ b/src/app/pages/annonces/mes-annonces/mes-annonces.html
@@ -4,6 +4,22 @@
   <main class="mes-annonces-container">
     <h1 class="page-title">MES ANNONCES</h1>
 
+    <!-- Filtres -->
+    <div class="filters-container">
+      <button
+        class="filter-btn"
+        [class.active]="filterType === 'avenir'"
+        (click)="setFilter('avenir')">
+        📅 À venir ({{ annoncesAvenir.length }})
+      </button>
+      <button
+        class="filter-btn"
+        [class.active]="filterType === 'passees'"
+        (click)="setFilter('passees')">
+        📜 Passées ({{ annoncesPassees.length }})
+      </button>
+    </div>
+
     <!-- Message d'erreur -->
     <div *ngIf="errorMessage" class="error-message">
       {{ errorMessage }}
@@ -16,7 +32,7 @@
     </div>
 
     <!-- Tableau des annonces -->
-    <div *ngIf="!isLoading && annonces && annonces.length > 0" class="annonces-table-container">
+    <div *ngIf="!isLoading && pagedAnnonces && pagedAnnonces.length > 0" class="annonces-table-container">
       <table class="annonces-table">
         <thead>
         <tr>
@@ -31,7 +47,8 @@
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let annonce of pagedAnnonces">
+        <tr *ngFor="let annonce of pagedAnnonces"
+            [class.row-passee]="filterType === 'passees'">
           <td>{{ formatHeureDepart(annonce.annonce.heureDepart) }}</td>
           <td>{{ formatAdresse(annonce.annonce.adresseDepart) }}</td>
           <td>{{ formatAdresse(annonce.annonce.adresseArrivee) }}</td>
@@ -53,7 +70,9 @@
               title="Voir les détails">
               <i class="icon-info">ℹ️</i>
             </button>
+
             <button
+              *ngIf="filterType === 'avenir'"
               class="action-btn edit-btn"
               (click)="modifierAnnonce(annonce)"
               [disabled]="!peutEtreModifiee(annonce)"
@@ -61,7 +80,9 @@
                 'Modifier' : 'Modification impossible (annonce réservée)'">
               <i class="icon-edit">✏️</i>
             </button>
+
             <button
+              *ngIf="filterType === 'avenir'"
               class="action-btn delete-btn"
               (click)="confirmerSuppression(annonce)"
               title="Supprimer">
@@ -71,6 +92,7 @@
         </tr>
         </tbody>
       </table>
+
       <div class="pagination">
         <button type="button" class="pager" (click)="prevPage()" [disabled]="currentPage === 1">Précédent</button>
         <span class="pager__info">Page {{ currentPage }} / {{ totalPages }}</span>
@@ -79,8 +101,9 @@
     </div>
 
     <!-- Message si aucune annonce -->
-    <div *ngIf="!isLoading && (!annonces || annonces.length === 0)" class="no-annonces">
-      <p>Vous n'avez pas encore créé d'annonce.</p>
+    <div *ngIf="!isLoading && (!pagedAnnonces || pagedAnnonces.length === 0)" class="no-annonces">
+      <p *ngIf="filterType === 'avenir'">Vous n'avez pas d'annonce à venir.</p>
+      <p *ngIf="filterType === 'passees'">Vous n'avez pas d'annonce passée.</p>
     </div>
 
     <!-- Bouton poster une annonce -->
@@ -94,7 +117,7 @@
   <app-footer></app-footer>
 </div>
 
-<!-- Modal de confirmation de suppression (en dehors du wrapper) -->
+<!-- Modal de confirmation de suppression -->
 <app-delete-confirmation-dialog
   [open]="showDeleteModal"
   [title]="'Confirmer la suppression'"
@@ -106,11 +129,20 @@
   (cancel)="annulerSuppression()">
 </app-delete-confirmation-dialog>
 
-<!-- Modale de détail d'annonce (en dehors du wrapper) -->
+<!-- Modale de détail d'annonce - MODIFICATION : Passer isAnnoncePassee -->
 <app-annonce-detail-modal
   [isOpen]="showDetailModal"
   [annonce]="selectedAnnonce"
   [conducteur]="{ prenom: currentUser?.prenom || '', nom: currentUser?.nom || '' }"
+  [isPassee]="filterType === 'passees'"
   (close)="closeDetailModal()"
   (annuler)="onAnnulerAnnonce($event)">
 </app-annonce-detail-modal>
+
+<!-- Modale de modification d'annonce -->
+<app-edit-annonce-modal
+  [isOpen]="showEditModal"
+  [annonce]="annonceToEdit"
+  (close)="closeEditModal()"
+  (updated)="onAnnonceUpdated()">
+</app-edit-annonce-modal>

--- a/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.css
+++ b/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.css
@@ -1,0 +1,409 @@
+/* Overlay de la modale */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+/* Container principal de la modale */
+.modal-container {
+  background: #EDEDED;
+  border-radius: 12px;
+  max-width: 1200px;
+  width: 95%;
+  max-height: 95vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+/* Header de la modale */
+.modal-header {
+  position: sticky;
+  top: 0;
+  background: #EDEDED;
+  padding: 1.5rem 2rem 1rem 2rem;
+  border-bottom: 2px solid #0B84A2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+  margin-bottom: 1rem;
+}
+
+.page-title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #333;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 28px;
+  color: #333;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: none; /* Masquer la croix de fermeture */
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.close-btn:hover {
+  background: #ddd;
+  color: #000;
+}
+
+/* Corps de la modale */
+.modal-body {
+  padding: 1rem 2rem 2rem 2rem;
+}
+
+/* Alerts */
+.alert {
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-weight: 500;
+}
+
+.alert-success {
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.alert-error {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+/* Form sections */
+.annonce-form {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+
+.form-section {
+  border: 2px solid #0B84A2;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  overflow: visible;
+  padding: 24px 24px 0 24px;
+  position: relative;
+  background: white;
+}
+
+.section-title {
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0B84A2;
+  color: white;
+  padding: 0.5rem 2rem;
+  border-radius: 15px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+/* Form groups */
+.form-group {
+  margin-bottom: 0.6rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 0.2rem;
+  text-transform: uppercase;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.4rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.90rem;
+  background: white;
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: #0B84A2;
+  box-shadow: 0 0 0 2px rgba(11, 132, 162, 0.1);
+}
+
+.form-control.error {
+  border-color: #dc3545;
+}
+
+.error-message {
+  color: #dc3545;
+  font-size: 0.8rem;
+  margin-top: 0.3rem;
+  display: block;
+}
+
+/* Form rows */
+.form-row {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.form-group.small {
+  flex: 0 0 70px;
+}
+
+.form-group.large {
+  flex: 1;
+}
+
+/* Section véhicule - prend 2 lignes */
+.form-section:nth-child(4) {
+  grid-column: 1 / 3;
+  grid-row: 2 / 4;
+}
+
+/* Input with suffix */
+.input-with-suffix {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.input-with-suffix .form-control {
+  flex: 1;
+}
+
+.suffix {
+  font-size: 0.85rem;
+  color: #666;
+  white-space: nowrap;
+}
+
+/* Titre secondaire dans la carte */
+.vehicule-subtitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.1rem;
+  text-align: left;
+}
+
+/* Ligne véhicule */
+.vehicule-row {
+  margin-bottom: 0.5rem;
+  padding: 0.4rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fafafa;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.vehicule-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.vehicule-content {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 45px;
+}
+
+.vehicule-photo-inline {
+  width: 60px;
+  height: 45px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  flex-shrink: 0;
+}
+
+.vehicule-text {
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  flex: 1;
+}
+
+.vehicule-immat-inline {
+  font-size: 12px;
+  color: #0B84A2;
+  font-weight: 600;
+  margin-right: 8rem;
+}
+
+.vehicule-checkbox-inline {
+  width: 22px;
+  height: 22px;
+  accent-color: #0B84A2;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.no-vehicule-inline {
+  font-size: 12px;
+  color: #999;
+  font-style: italic;
+  line-height: 45px;
+}
+
+/* Bouton réserver */
+.btn-reserver {
+  width: 50%;
+  margin-bottom: 0.5rem;
+  padding: 0.7rem;
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  transition: all 0.3s;
+}
+
+.btn-reserver:hover {
+  background-color: #5a6268;
+}
+
+.loading-spinner {
+  text-align: center;
+  padding: 2rem;
+  color: #0B84A2;
+}
+
+/* Buttons */
+.form-actions {
+  grid-column: 3;
+  grid-row: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: flex-start;
+  margin-top: 0;
+  align-items: center;
+}
+
+.btn-cancel,
+.btn-submit {
+  padding: 0.8rem 2rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s;
+  text-transform: uppercase;
+  width: 60%;
+}
+
+.btn-cancel {
+  background-color: #6c757d;
+  color: white;
+}
+
+.btn-cancel:hover {
+  background-color: #5a6268;
+}
+
+.btn-submit {
+  background-color: #ccc;
+  color: #888;
+  cursor: not-allowed;
+}
+
+.btn-submit.active {
+  background-color: #0B84A2;
+  color: white;
+  cursor: pointer;
+}
+
+.btn-submit.active:hover {
+  background-color: #0a6d87;
+}
+
+.btn-submit:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .annonce-form {
+    grid-template-columns: 1fr;
+  }
+
+  .form-section:nth-child(4) {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .form-actions {
+    grid-column: 1;
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .modal-container {
+    width: 98%;
+    max-height: 98vh;
+  }
+
+  .modal-header {
+    padding: 1rem;
+  }
+
+  .modal-body {
+    padding: 1rem;
+  }
+
+  .form-row {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .form-group.small {
+    flex: 1;
+  }
+
+  .btn-cancel,
+  .btn-submit {
+    width: 100%;
+  }
+}

--- a/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.html
+++ b/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.html
@@ -1,0 +1,329 @@
+<div class="modal-overlay" *ngIf="isOpen" (click)="onClose()">
+  <div class="modal-container" (click)="$event.stopPropagation()">
+
+    <!-- Header de la modale -->
+    <div class="modal-header">
+      <h1 class="page-title">Modifier mon annonce</h1>
+      <button class="close-btn" (click)="onClose()" title="Fermer">✕</button>
+    </div>
+
+    <!-- Corps de la modale -->
+    <div class="modal-body">
+
+      <!-- Messages -->
+      <div class="alert alert-success" *ngIf="successMessage">
+        {{ successMessage }}
+      </div>
+      <div class="alert alert-error" *ngIf="errorMessage">
+        {{ errorMessage }}
+      </div>
+
+      <form [formGroup]="annonceForm" (ngSubmit)="onSubmit()" class="annonce-form">
+
+        <!-- Section Date et Heure -->
+        <div class="form-section">
+          <h3 class="section-title">Annonce</h3>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label for="dateDepart">Date de départ *</label>
+              <input
+                type="date"
+                id="dateDepart"
+                formControlName="dateDepart"
+                [min]="minDate"
+                class="form-control"
+                [class.error]="annonceForm.get('dateDepart')?.invalid && annonceForm.get('dateDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('dateDepart')?.hasError('required') && annonceForm.get('dateDepart')?.touched">
+                La date est requise
+              </span>
+              <span class="error-message"
+                    *ngIf="annonceForm.get('dateDepart')?.hasError('dateInPast') && annonceForm.get('dateDepart')?.touched">
+                La date ne peut pas être dans le passé
+              </span>
+            </div>
+
+            <div class="form-group">
+              <label for="heureDepart">Heure de départ *</label>
+              <input
+                type="time"
+                id="heureDepart"
+                formControlName="heureDepart"
+                class="form-control"
+                [class.error]="annonceForm.get('heureDepart')?.invalid && annonceForm.get('heureDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('heureDepart')?.invalid && annonceForm.get('heureDepart')?.touched">
+              L'heure est requise
+            </span>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label for="dureeTrajet">Durée du trajet *</label>
+              <div class="input-with-suffix">
+                <input
+                  type="number"
+                  id="dureeTrajet"
+                  formControlName="dureeTrajet"
+                  class="form-control"
+                  placeholder="Ex: 30"
+                  [class.error]="annonceForm.get('dureeTrajet')?.invalid && annonceForm.get('dureeTrajet')?.touched">
+                <span class="suffix">minutes</span>
+              </div>
+              <span class="error-message"
+                    *ngIf="annonceForm.get('dureeTrajet')?.invalid && annonceForm.get('dureeTrajet')?.touched">
+              La durée est requise (min. 1 minute)
+            </span>
+            </div>
+
+            <div class="form-group">
+              <label for="distance">Distance *</label>
+              <div class="input-with-suffix">
+                <input
+                  type="number"
+                  id="distance"
+                  formControlName="distance"
+                  class="form-control"
+                  placeholder="Ex: 25"
+                  [class.error]="annonceForm.get('distance')?.invalid && annonceForm.get('distance')?.touched">
+                <span class="suffix">kilomètres</span>
+              </div>
+              <span class="error-message"
+                    *ngIf="annonceForm.get('distance')?.invalid && annonceForm.get('distance')?.touched">
+              La distance est requise (min. 1 km)
+            </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section Adresse de départ -->
+        <div class="form-section">
+          <h3 class="section-title">Adresse de départ</h3>
+
+          <div class="form-row">
+            <div class="form-group small">
+              <label for="numeroDepart">N° *</label>
+              <input
+                type="number"
+                id="numeroDepart"
+                formControlName="numeroDepart"
+                class="form-control"
+                placeholder="12"
+                [class.error]="annonceForm.get('numeroDepart')?.invalid && annonceForm.get('numeroDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('numeroDepart')?.invalid && annonceForm.get('numeroDepart')?.touched">
+              Requis
+            </span>
+            </div>
+
+            <div class="form-group large">
+              <label for="libelleDepart">Rue *</label>
+              <input
+                type="text"
+                id="libelleDepart"
+                formControlName="libelleDepart"
+                class="form-control"
+                placeholder="Rue de la République"
+                [class.error]="annonceForm.get('libelleDepart')?.invalid && annonceForm.get('libelleDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('libelleDepart')?.invalid && annonceForm.get('libelleDepart')?.touched">
+              L'adresse est requise
+            </span>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label for="codePostalDepart">Code postal *</label>
+              <input
+                type="text"
+                id="codePostalDepart"
+                formControlName="codePostalDepart"
+                class="form-control"
+                placeholder="34000"
+                maxlength="5"
+                [class.error]="annonceForm.get('codePostalDepart')?.invalid && annonceForm.get('codePostalDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('codePostalDepart')?.invalid && annonceForm.get('codePostalDepart')?.touched">
+              Code postal invalide (5 chiffres)
+            </span>
+            </div>
+
+            <div class="form-group">
+              <label for="villeDepart">Ville *</label>
+              <input
+                type="text"
+                id="villeDepart"
+                formControlName="villeDepart"
+                class="form-control"
+                placeholder="Montpellier"
+                [class.error]="annonceForm.get('villeDepart')?.invalid && annonceForm.get('villeDepart')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('villeDepart')?.invalid && annonceForm.get('villeDepart')?.touched">
+              La ville est requise
+            </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section Adresse d'arrivée -->
+        <div class="form-section">
+          <h3 class="section-title">Adresse d'arrivée</h3>
+
+          <div class="form-row">
+            <div class="form-group small">
+              <label for="numeroArrivee">N° *</label>
+              <input
+                type="number"
+                id="numeroArrivee"
+                formControlName="numeroArrivee"
+                class="form-control"
+                placeholder="5"
+                [class.error]="annonceForm.get('numeroArrivee')?.invalid && annonceForm.get('numeroArrivee')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('numeroArrivee')?.invalid && annonceForm.get('numeroArrivee')?.touched">
+              Requis
+            </span>
+            </div>
+
+            <div class="form-group large">
+              <label for="libelleArrivee">Rue *</label>
+              <input
+                type="text"
+                id="libelleArrivee"
+                formControlName="libelleArrivee"
+                class="form-control"
+                placeholder="Avenue de la Liberté"
+                [class.error]="annonceForm.get('libelleArrivee')?.invalid && annonceForm.get('libelleArrivee')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('libelleArrivee')?.invalid && annonceForm.get('libelleArrivee')?.touched">
+              L'adresse est requise
+            </span>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group">
+              <label for="codePostalArrivee">Code postal *</label>
+              <input
+                type="text"
+                id="codePostalArrivee"
+                formControlName="codePostalArrivee"
+                class="form-control"
+                placeholder="34090"
+                maxlength="5"
+                [class.error]="annonceForm.get('codePostalArrivee')?.invalid && annonceForm.get('codePostalArrivee')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('codePostalArrivee')?.invalid && annonceForm.get('codePostalArrivee')?.touched">
+              Code postal invalide (5 chiffres)
+            </span>
+            </div>
+
+            <div class="form-group">
+              <label for="villeArrivee">Ville *</label>
+              <input
+                type="text"
+                id="villeArrivee"
+                formControlName="villeArrivee"
+                class="form-control"
+                placeholder="Nîmes"
+                [class.error]="annonceForm.get('villeArrivee')?.invalid && annonceForm.get('villeArrivee')?.touched">
+              <span class="error-message"
+                    *ngIf="annonceForm.get('villeArrivee')?.invalid && annonceForm.get('villeArrivee')?.touched">
+              La ville est requise
+            </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section Véhicule -->
+        <div class="form-section">
+          <h3 class="section-title">Véhicules</h3>
+
+          <div class="loading-spinner" *ngIf="loadingVehicules">
+            Chargement des véhicules...
+          </div>
+
+          <div class="vehicules-container" *ngIf="!loadingVehicules">
+            <h4 class="vehicule-subtitle">Choisissez votre véhicule</h4>
+
+            <!-- Ligne Véhicule Personnel -->
+            <div class="vehicule-row">
+              <label class="vehicule-label">Votre véhicule personnel :</label>
+
+              <div class="vehicule-content" *ngIf="hasVehiculePersonnel">
+                <img [src]="vehiculePersonnel!.photo"
+                     [alt]="vehiculePersonnel!.marque"
+                     class="vehicule-photo-inline">
+                <span class="vehicule-text">{{ vehiculePersonnel!.marque }} {{ vehiculePersonnel!.modele }}</span>
+                <span class="vehicule-immat-inline">{{ vehiculePersonnel!.immatriculation }}</span>
+                <input
+                  type="checkbox"
+                  [checked]="useVehiculePersonnel"
+                  (change)="selectVehicule('personnel')"
+                  class="vehicule-checkbox-inline">
+              </div>
+
+              <div class="vehicule-content" *ngIf="!hasVehiculePersonnel">
+                <span class="no-vehicule-inline">Pas de véhicule déclaré</span>
+              </div>
+            </div>
+
+            <!-- Ligne Véhicule Entreprise -->
+            <div class="vehicule-row">
+              <label class="vehicule-label">Véhicule de société :</label>
+
+              <div class="vehicule-content" *ngIf="hasVehiculeEntreprise">
+                <img [src]="vehiculeEntreprise!.photo"
+                     [alt]="vehiculeEntreprise!.marque"
+                     class="vehicule-photo-inline">
+                <span class="vehicule-text">{{ vehiculeEntreprise!.marque }} {{ vehiculeEntreprise!.modele }}</span>
+                <span class="vehicule-immat-inline">{{ vehiculeEntreprise!.immatriculation }}</span>
+                <input
+                  type="checkbox"
+                  [checked]="useVehiculeEntreprise"
+                  (change)="selectVehicule('entreprise')"
+                  class="vehicule-checkbox-inline">
+              </div>
+
+              <div class="vehicule-content" *ngIf="!hasVehiculeEntreprise">
+                <span class="no-vehicule-inline">Aucun véhicule disponible pour cette date</span>
+              </div>
+            </div>
+
+            <!-- Bouton réserver -->
+            <button type="button" class="btn-reserver" routerLink="/vehicules/reservation">
+              RÉSERVER UN AUTRE VÉHICULE DE SOCIÉTÉ
+            </button>
+
+            <div class="error-message" *ngIf="!useVehiculePersonnel && !useVehiculeEntreprise && annonceForm.touched">
+              Veuillez sélectionner un véhicule
+            </div>
+          </div>
+        </div>
+
+        <!-- Boutons d'action -->
+        <div class="form-actions">
+          <button
+            type="button"
+            class="btn-cancel"
+            (click)="onCancel()"
+            [disabled]="loading">
+            ANNULER
+          </button>
+
+          <button
+            type="submit"
+            class="btn-submit"
+            [class.active]="isFormValid()"
+            [disabled]="!isFormValid() || loading">
+            {{ loading ? 'MODIFICATION EN COURS...' : 'MODIFIER L\'ANNONCE' }}
+          </button>
+        </div>
+
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.spec.ts
+++ b/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditAnnonceModal } from './edit-annonce-modal';
+
+describe('EditAnnonceModal', () => {
+  let component: EditAnnonceModal;
+  let fixture: ComponentFixture<EditAnnonceModal>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EditAnnonceModal]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EditAnnonceModal);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.ts
+++ b/src/app/pages/annonces/modales/edit-annonce-modal/edit-annonce-modal.ts
@@ -1,0 +1,291 @@
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { CreateAnnonceService, VehiculePersonnel, VehiculeEntreprise, ReservationVehicule, AnnonceRequest } from '../../../../services/annonces/create-annonce/create-annonce';
+import { Annonce } from '../../../../models/annonce';
+
+@Component({
+  selector: 'app-edit-annonce-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule
+  ],
+  templateUrl: './edit-annonce-modal.html',
+  styleUrls: ['./edit-annonce-modal.css']
+})
+export class EditAnnonceModalComponent implements OnInit, OnChanges {
+  @Input() isOpen: boolean = false;
+  @Input() annonce: Annonce | null = null;
+  @Output() close = new EventEmitter<void>();
+  @Output() updated = new EventEmitter<void>();
+
+  annonceForm!: FormGroup;
+
+  // Véhicules
+  vehiculePersonnel: VehiculePersonnel | null = null;
+  vehiculeEntreprise: VehiculeEntreprise | null = null;
+  hasVehiculePersonnel = false;
+  hasVehiculeEntreprise = false;
+
+  // Choix utilisateur
+  useVehiculePersonnel = false;
+  useVehiculeEntreprise = false;
+
+  // États
+  loading = false;
+  loadingVehicules = true;
+  errorMessage = '';
+  successMessage = '';
+
+  // Date minimale (aujourd'hui)
+  minDate: string;
+
+  constructor(
+    private fb: FormBuilder,
+    private createAnnonceService: CreateAnnonceService
+  ) {
+    const today = new Date();
+    this.minDate = today.toISOString().split('T')[0];
+  }
+
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['annonce'] && this.annonce && this.isOpen) {
+      this.loadVehiculePersonnel();
+      this.prefillForm();
+    }
+  }
+
+  // Validateur personnalisé pour la date
+  dateNotInPastValidator(control: AbstractControl): ValidationErrors | null {
+    if (!control.value) {
+      return null;
+    }
+
+    const selectedDate = new Date(control.value);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    if (selectedDate < today) {
+      return { dateInPast: true };
+    }
+
+    return null;
+  }
+
+  initForm(): void {
+    this.annonceForm = this.fb.group({
+      dateDepart: ['', [Validators.required, this.dateNotInPastValidator.bind(this)]],
+      heureDepart: ['', Validators.required],
+      dureeTrajet: ['', [Validators.required, Validators.min(1)]],
+      distance: ['', [Validators.required, Validators.min(1)]],
+
+      // Adresse départ
+      numeroDepart: ['', [Validators.required, Validators.min(1)]],
+      libelleDepart: ['', Validators.required],
+      codePostalDepart: ['', [Validators.required, Validators.pattern(/^\d{5}$/)]],
+      villeDepart: ['', Validators.required],
+
+      // Adresse arrivée
+      numeroArrivee: ['', [Validators.required, Validators.min(1)]],
+      libelleArrivee: ['', Validators.required],
+      codePostalArrivee: ['', [Validators.required, Validators.pattern(/^\d{5}$/)]],
+      villeArrivee: ['', Validators.required]
+    });
+
+    // Surveiller les changements de date pour chercher véhicule entreprise
+    this.annonceForm.get('dateDepart')?.valueChanges.subscribe(() => {
+      this.checkVehiculeEntreprise();
+    });
+
+    this.annonceForm.get('heureDepart')?.valueChanges.subscribe(() => {
+      this.checkVehiculeEntreprise();
+    });
+  }
+
+  prefillForm(): void {
+    if (!this.annonce) return;
+
+    // Extraire date et heure de heureDepart
+    const heureDepartDate = new Date(this.annonce.annonce.heureDepart);
+    const dateDepart = heureDepartDate.toISOString().split('T')[0];
+    const heureDepart = heureDepartDate.toTimeString().slice(0, 5);
+
+    this.annonceForm.patchValue({
+      dateDepart: dateDepart,
+      heureDepart: heureDepart,
+      dureeTrajet: this.annonce.annonce.dureeTrajet,
+      distance: this.annonce.annonce.distance,
+
+      // Adresse départ
+      numeroDepart: this.annonce.annonce.adresseDepart.numero,
+      libelleDepart: this.annonce.annonce.adresseDepart.libelle,
+      codePostalDepart: this.annonce.annonce.adresseDepart.codePostal,
+      villeDepart: this.annonce.annonce.adresseDepart.ville,
+
+      // Adresse arrivée
+      numeroArrivee: this.annonce.annonce.adresseArrivee.numero,
+      libelleArrivee: this.annonce.annonce.adresseArrivee.libelle,
+      codePostalArrivee: this.annonce.annonce.adresseArrivee.codePostal,
+      villeArrivee: this.annonce.annonce.adresseArrivee.ville
+    });
+
+    // Définir le véhicule sélectionné
+    if (this.annonce.annonce.vehiculeServiceId) {
+      this.useVehiculeEntreprise = true;
+      this.useVehiculePersonnel = false;
+    } else {
+      this.useVehiculePersonnel = true;
+      this.useVehiculeEntreprise = false;
+    }
+  }
+
+  loadVehiculePersonnel(): void {
+    this.createAnnonceService.getVehiculePersonnel().subscribe({
+      next: (vehicule) => {
+        this.vehiculePersonnel = vehicule;
+        this.hasVehiculePersonnel = true;
+        this.loadingVehicules = false;
+        this.checkVehiculeEntreprise();
+      },
+      error: (error) => {
+        console.log('Pas de véhicule personnel trouvé:', error);
+        this.hasVehiculePersonnel = false;
+        this.loadingVehicules = false;
+      }
+    });
+  }
+
+  checkVehiculeEntreprise(): void {
+    const dateDepart = this.annonceForm.get('dateDepart')?.value;
+    const heureDepart = this.annonceForm.get('heureDepart')?.value;
+
+    if (!dateDepart || !heureDepart) {
+      return;
+    }
+
+    const dateTimeDepart = new Date(`${dateDepart}T${heureDepart}`);
+
+    this.createAnnonceService.getReservationsVehicules().subscribe({
+      next: (reservations: ReservationVehicule[]) => {
+        const reservationValide = reservations.find(res => {
+          const debut = new Date(res.dateDebut);
+          const fin = new Date(res.dateFin);
+          return dateTimeDepart >= debut && dateTimeDepart <= fin;
+        });
+
+        if (reservationValide) {
+          this.loadVehiculeEntreprise(reservationValide.vehiculeId);
+        } else {
+          this.vehiculeEntreprise = null;
+          this.hasVehiculeEntreprise = false;
+        }
+      },
+      error: (error) => {
+        console.error('Erreur lors de la récupération des réservations:', error);
+        this.vehiculeEntreprise = null;
+        this.hasVehiculeEntreprise = false;
+      }
+    });
+  }
+
+  loadVehiculeEntreprise(vehiculeId: number): void {
+    this.createAnnonceService.getVehiculeEntreprise(vehiculeId).subscribe({
+      next: (vehicule) => {
+        this.vehiculeEntreprise = vehicule;
+        this.hasVehiculeEntreprise = true;
+      },
+      error: (error) => {
+        console.error('Erreur lors du chargement du véhicule entreprise:', error);
+        this.vehiculeEntreprise = null;
+        this.hasVehiculeEntreprise = false;
+      }
+    });
+  }
+
+  selectVehicule(type: 'personnel' | 'entreprise'): void {
+    if (type === 'personnel') {
+      this.useVehiculePersonnel = true;
+      this.useVehiculeEntreprise = false;
+    } else {
+      this.useVehiculePersonnel = false;
+      this.useVehiculeEntreprise = true;
+    }
+  }
+
+  isFormValid(): boolean {
+    return this.annonceForm.valid &&
+           (this.useVehiculePersonnel || this.useVehiculeEntreprise);
+  }
+
+  onSubmit(): void {
+    if (!this.isFormValid() || !this.annonce) {
+      this.errorMessage = 'Veuillez remplir tous les champs et sélectionner un véhicule';
+      return;
+    }
+
+    this.loading = true;
+    this.errorMessage = '';
+
+    const formValue = this.annonceForm.value;
+    const dateTimeDepart = `${formValue.dateDepart}T${formValue.heureDepart}:00.000Z`;
+
+    const annonceRequest: AnnonceRequest = {
+      id: this.annonce.annonce.id,
+      heureDepart: dateTimeDepart,
+      dureeTrajet: Number(formValue.dureeTrajet),
+      distance: Number(formValue.distance),
+      adresseDepart: {
+        id: this.annonce.annonce.adresseDepart.id,
+        numero: Number(formValue.numeroDepart),
+        libelle: formValue.libelleDepart,
+        codePostal: formValue.codePostalDepart,
+        ville: formValue.villeDepart
+      },
+      adresseArrivee: {
+        id: this.annonce.annonce.adresseArrivee.id,
+        numero: Number(formValue.numeroArrivee),
+        libelle: formValue.libelleArrivee,
+        codePostal: formValue.codePostalArrivee,
+        ville: formValue.villeArrivee
+      },
+      vehiculeServiceId: this.useVehiculeEntreprise && this.vehiculeEntreprise
+        ? this.vehiculeEntreprise.id
+        : null
+    };
+
+    this.createAnnonceService.modifierAnnonce(this.annonce.annonce.id, annonceRequest).subscribe({
+      next: (response: any) => {
+        this.successMessage = 'Annonce modifiée avec succès !';
+        this.loading = false;
+
+        setTimeout(() => {
+          this.updated.emit();
+          this.onClose();
+        }, 1500);
+      },
+      error: (error: any) => {
+        console.error('Erreur lors de la modification de l\'annonce:', error);
+        this.errorMessage = 'Erreur lors de la modification de l\'annonce. Veuillez réessayer.';
+        this.loading = false;
+      }
+    });
+  }
+
+  onClose(): void {
+    this.close.emit();
+    this.errorMessage = '';
+    this.successMessage = '';
+  }
+
+  onCancel(): void {
+    this.onClose();
+  }
+}

--- a/src/app/services/annonces/create-annonce/create-annonce.ts
+++ b/src/app/services/annonces/create-annonce/create-annonce.ts
@@ -99,4 +99,13 @@ export class CreateAnnonceService {
       { headers: this.getHeaders() }
     );
   }
+
+  // AJOUT : Méthode pour modifier une annonce
+  modifierAnnonce(id: number, annonce: AnnonceRequest): Observable<any> {
+    return this.http.put<any>(
+      `${this.baseUrl}/api/covoit/${id}`,
+      annonce,
+      { headers: this.getHeaders() }
+    );
+  }
 }

--- a/src/app/shared/modales/annonce-detail-modal/annonce-detail-modal.html
+++ b/src/app/shared/modales/annonce-detail-modal/annonce-detail-modal.html
@@ -96,7 +96,13 @@
     <!-- BLOC 4 : ACTIONS -->
     <div class="modal-footer">
       <button class="btn-secondary" (click)="onClose()">Fermer</button>
-      <button class="btn-danger" (click)="onAnnuler()">Annuler l'annonce</button>
+      <!-- Masquer le bouton Annuler si l'annonce est passée -->
+      <button
+        *ngIf="!isPassee"
+        class="btn-danger"
+        (click)="onAnnuler()">
+        Annuler l'annonce
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/shared/modales/annonce-detail-modal/annonce-detail-modal.ts
+++ b/src/app/shared/modales/annonce-detail-modal/annonce-detail-modal.ts
@@ -13,6 +13,7 @@ export class AnnonceDetailModalComponent implements OnChanges {
   @Input() annonce: any;
   @Input() conducteur: any;
   @Input() isOpen: boolean = false;
+  @Input() isPassee: boolean = false;
   @Output() close = new EventEmitter<void>();
   @Output() annuler = new EventEmitter<number>();
 


### PR DESCRIPTION
+ amélioration page Mes annonces
La modale de modification est accessible depuis la page Mes annonces en cliquant sur l'icône représentant un crayon.
Un tri est effectué sur les dates.
Les annonces passées sont grisées, les boutons d'action poubelle et crayon supprimés, et si l'on regarde les détails de l'annonce passée, on ne peut plus supprimée cette annonce.
Fix de la position du footer sur la page Mes annonces. Changement de la mise en page avec 5 enregistrements par page.